### PR TITLE
MVP2 supplies and probe types

### DIFF
--- a/itm-api.yaml
+++ b/itm-api.yaml
@@ -462,6 +462,8 @@ components:
       enum:
       - denial
       - mission
+      - timeurg
+      - risktol
       - Knowledge
       type: string
       description: Possible KDMA names.

--- a/itm-api.yaml
+++ b/itm-api.yaml
@@ -602,6 +602,8 @@ components:
       - MultipleChoice
       - FreeResponse
       - PatientOrdering
+      - SelectTag
+      - SelectTreatment
       type: string
       description: Describes the type of probe being asked (multiple choice, patient
         ordering, etc)

--- a/itm-api.yaml
+++ b/itm-api.yaml
@@ -698,6 +698,10 @@ components:
       - Oropharangeal-Airway
       - Cric Kit
       - Alcohol Swabs
+      - Hemostatic Gauze
+      - Needle Decompression
+      - Bandage
+      - Pain Medication
       type: string
       description: Enum over possible supply types.
     Threat:


### PR DESCRIPTION
This PR adds a few Enums to support the TA3 testbed and TA1 probes and KDMAs

### KDMAs

Two additional KDMAs used by SoarTech

  - `timeurg`: Time Urgency
  - `rosktol`: Risk Tolerance

### Probe Types

  - `SelectTag`: Select a tag to apply
    - The `value` field will always be one of the following
      - `Green Tag`  
      - `Yellow Tag`  
      - `Red Tag`  
      - `Black Tag`  
  - `SelectTreatment`: Select a piece of equipment to apply as treatment
    - The `value` field will always be a `SupplyType` (from the `SupplyType` enum) or the literal values `"Assessment"` or `"No Treatment"`  

### Supplies

These were added to mirror the supplies available in the TA3 testbed

  - `Hemostatic Gauze`
  - `Needle Decompression`
  - `Bandage`
  - `Pain Medication`